### PR TITLE
Move library structs into the dictionary

### DIFF
--- a/src/dictionary/case.rs
+++ b/src/dictionary/case.rs
@@ -1,0 +1,56 @@
+use std::str::FromStr;
+
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+pub enum Case {
+    Snake,
+    Kebab,
+    Pascal,
+    Camel,
+    Title,
+    Sentence,
+    Lower,
+    Upper,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum ParseCaseError {
+    InvalidFormat,
+}
+
+impl FromStr for Case {
+    type Err = ParseCaseError;
+
+    fn from_str(format: &str) -> Result<Case, ParseCaseError> {
+        let case = match format {
+            "snake" => Case::Snake,
+            "kebab" => Case::Kebab,
+            "pascal" => Case::Pascal,
+            "camel" => Case::Camel,
+            "title" => Case::Title,
+            "sentence" => Case::Sentence,
+            "lower" => Case::Lower,
+            "upper" => Case::Upper,
+            _ => return Err(ParseCaseError::InvalidFormat),
+        };
+
+        Ok(case)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn str_can_be_parsed_to_a_format() {
+        assert_eq!(Case::Snake, "snake".parse::<Case>().unwrap());
+        assert_eq!(Case::Kebab, "kebab".parse::<Case>().unwrap());
+        assert_eq!(Case::Camel, "camel".parse::<Case>().unwrap());
+        assert_eq!(Case::Pascal, "pascal".parse::<Case>().unwrap());
+        assert_eq!(Case::Title, "title".parse::<Case>().unwrap());
+        assert_eq!(Case::Sentence, "sentence".parse::<Case>().unwrap());
+        assert_eq!(Case::Lower, "lower".parse::<Case>().unwrap());
+        assert_eq!(Case::Upper, "upper".parse::<Case>().unwrap());
+        assert!("alsdkfj".parse::<Case>().is_err());
+    }
+}

--- a/src/dictionary/mod.rs
+++ b/src/dictionary/mod.rs
@@ -1,6 +1,41 @@
-pub mod adverbs;
-pub mod adjectives;
-pub mod nouns;
+mod adverbs;
+mod adjectives;
+mod nouns;
+mod case;
+mod sha_result;
+mod sha_part;
+mod phrase;
+
+pub use self::case::Case;
+
+use self::phrase::Phrase;
+use self::sha_result::{ShaResult, ParseShaError};
+use self::sha_part::ShaPart;
+
+pub fn lookup(sha: &str) -> ShaResult<Phrase> {
+    sha.parse()
+}
+
+fn lookup_adverb(part: ShaPart) -> ShaResult<String> {
+    adverbs::WORDS
+        .get(part.hash() % adverbs::WORDS.len())
+        .map(|s| s.to_string())
+        .ok_or(ParseShaError::WordNotFound)
+}
+
+fn lookup_adjective(part: ShaPart) -> ShaResult<String> {
+    adjectives::WORDS
+        .get(part.hash() % adjectives::WORDS.len())
+        .map(|s| s.to_string())
+        .ok_or(ParseShaError::WordNotFound)
+}
+
+fn lookup_noun(part: ShaPart) -> ShaResult<String> {
+    nouns::WORDS
+        .get(part.hash() % nouns::WORDS.len())
+        .map(|s| s.to_string())
+        .ok_or(ParseShaError::WordNotFound)
+}
 
 #[cfg(test)]
 mod tests {
@@ -35,5 +70,29 @@ mod tests {
     #[test]
     fn nouns_are_unique() {
         assert!(has_unique_elements(nouns::WORDS.iter()));
+    }
+
+    #[test]
+    fn it_can_look_up_from_an_adverb() {
+        let word = lookup_adverb("1".parse().unwrap());
+        assert_eq!(word, Ok("exaggeratedly".to_string()));
+        let word = lookup_adverb("ffff".parse().unwrap());
+        assert_eq!(word, Ok("disconcertingly".to_string()));
+    }
+
+    #[test]
+    fn it_can_look_up_an_adjective() {
+        let word = lookup_adjective("1".parse().unwrap());
+        assert_eq!(word, Ok("courant".to_string()));
+        let word = lookup_adjective("ffff".parse().unwrap());
+        assert_eq!(word, Ok("gleeful".to_string()));
+    }
+
+    #[test]
+    fn it_can_look_up_a_noun() {
+        let word = lookup_noun("1".parse().unwrap());
+        assert_eq!(word, Ok("ombre".to_string()));
+        let word = lookup_noun("ffff".parse().unwrap());
+        assert_eq!(word, Ok("tipsters".to_string()));
     }
 }

--- a/src/dictionary/phrase.rs
+++ b/src/dictionary/phrase.rs
@@ -1,0 +1,120 @@
+use std::fmt::{Display, Formatter, Error};
+use std::str::FromStr;
+use dictionary::sha_result::{ParseShaError, ShaResult};
+use dictionary::case::{Case};
+use dictionary;
+
+pub struct Phrase {
+    adj: String,
+    adv: String,
+    noun: String,
+    format: Case,
+}
+
+impl Phrase {
+    pub fn with_case(mut self, f: Case) -> Self {
+        self.format = f;
+        self
+    }
+}
+
+impl FromStr for Phrase {
+    type Err = ParseShaError;
+
+    fn from_str(sha: &str) -> ShaResult<Phrase> {
+        // Ensure that the sha is at least 8 characters so that
+        // when we extract the first 8 there is something there.
+        let sha = format!("{:0>8}", sha);
+        let adv = dictionary::lookup_adverb(sha[0..3].parse()?)?;
+        let adj = dictionary::lookup_adjective(sha[3..5].parse()?)?;
+        let noun = dictionary::lookup_noun(sha[5..8].parse()?)?;
+
+        Ok(Phrase {
+            adv,
+            adj,
+            noun,
+            format: Case::Lower,
+        })
+    }
+}
+
+impl Display for Phrase {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
+        use inflector::Inflector;
+
+        let ret = format!("{} {} {}", self.adv, self.adj, self.noun);
+        match self.format {
+            Case::Snake => write!(f, "{}", ret.to_snake_case()),
+            Case::Kebab => write!(f, "{}", ret.to_kebab_case()),
+            Case::Pascal => write!(f, "{}", ret.to_pascal_case()),
+            Case::Camel => write!(f, "{}", ret.to_camel_case()),
+            Case::Title => write!(f, "{}", ret.to_title_case()),
+            Case::Sentence => write!(f, "{}", ret.to_sentence_case()),
+            Case::Lower => write!(f, "{}", ret),
+            Case::Upper => write!(f, "{}", ret.to_uppercase()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_simple_phrase() -> Phrase {
+        "0a00a00a".parse::<Phrase>().expect("Invalid phrase")
+    }
+
+    #[test]
+    fn a_phrase_can_be_generated_from_a_str() {
+        let phrase = make_simple_phrase();
+        assert_eq!("immeasurably endways borings", format!("{}", phrase));
+    }
+
+    #[test]
+    fn a_phrase_can_be_formatted_as_snake_case() {
+        let phrase = make_simple_phrase().with_case(Case::Snake);
+        assert_eq!("immeasurably_endways_borings", format!("{}", phrase));
+    }
+
+    #[test]
+    fn a_phrase_can_be_formatted_as_kebab_case() {
+        let phrase = make_simple_phrase().with_case(Case::Kebab);
+        assert_eq!("immeasurably-endways-borings", format!("{}", phrase));
+    }
+
+    #[test]
+    fn a_phrase_can_be_formatted_as_camel_case() {
+        let phrase = make_simple_phrase().with_case(Case::Camel);
+        assert_eq!("immeasurablyEndwaysBorings", format!("{}", phrase));
+    }
+
+    #[test]
+    fn a_phrase_can_be_formatted_as_pascal_case() {
+        let phrase = make_simple_phrase().with_case(Case::Pascal);
+        assert_eq!("ImmeasurablyEndwaysBorings", format!("{}", phrase));
+    }
+
+    #[test]
+    fn a_phrase_can_be_formatted_as_title_case() {
+        let phrase = make_simple_phrase().with_case(Case::Title);
+        assert_eq!("Immeasurably Endways Borings", format!("{}", phrase));
+    }
+
+    #[test]
+    fn a_phrase_can_be_formatted_as_capital_case() {
+        let phrase = make_simple_phrase().with_case(Case::Sentence);
+        assert_eq!("Immeasurably endways borings", format!("{}", phrase));
+    }
+
+    #[test]
+    fn a_phrase_can_be_formatted_as_upper_case() {
+        let phrase = make_simple_phrase().with_case(Case::Upper);
+        assert_eq!("IMMEASURABLY ENDWAYS BORINGS", format!("{}", phrase));
+    }
+
+    #[test]
+    fn a_phrase_can_be_formatted_as_lower_case() {
+        let phrase = make_simple_phrase().with_case(Case::Lower);
+        assert_eq!("immeasurably endways borings", format!("{}", phrase));
+    }
+}

--- a/src/dictionary/sha_part.rs
+++ b/src/dictionary/sha_part.rs
@@ -1,0 +1,41 @@
+use std::str::FromStr;
+use dictionary::sha_result::{ParseShaError, ShaResult};
+
+#[derive(Debug)]
+pub struct ShaPart {
+    sha: String,
+    hash: usize,
+}
+
+impl ShaPart {
+    pub fn hash(&self) -> usize {
+        self.hash
+    }
+}
+
+impl FromStr for ShaPart {
+    type Err = ParseShaError;
+
+    fn from_str(sha: &str) -> ShaResult<ShaPart> {
+        if let Ok(hash) = usize::from_str_radix(&sha, 16) {
+            Ok(ShaPart { sha: sha.to_string(), hash })
+        } else {
+            Err(ParseShaError::NonHexadecimalCharacters)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_can_parse_into_a_word() {
+        assert_eq!("a".parse::<ShaPart>().unwrap().hash(), 10);
+    }
+
+    #[test]
+    fn it_can_detect_non_hex_chars() {
+        assert!("z".parse::<ShaPart>().is_err());
+    }
+}

--- a/src/dictionary/sha_result.rs
+++ b/src/dictionary/sha_result.rs
@@ -1,0 +1,7 @@
+#[derive(Debug, Eq, PartialEq)]
+pub enum ParseShaError {
+    NonHexadecimalCharacters,
+    WordNotFound,
+}
+
+pub type ShaResult<T> = Result<T, ParseShaError>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,148 +3,12 @@ extern crate atty;
 extern crate clap;
 extern crate inflector;
 
-use std::fmt::{Display, Formatter, Error};
 use std::io::{self, BufRead};
 use atty::Stream;
 use clap::{Arg, App, ArgMatches};
-use std::str::FromStr;
 
 mod dictionary;
-
-#[derive(Debug, Eq, PartialEq)]
-enum ParsePhraseError {
-    NonHexadecimalCharacters,
-}
-
-type ShaResult<T> = Result<T, ParsePhraseError>;
-
-#[derive(Debug)]
-struct Word {
-    sha: String,
-    hash: usize,
-    word: Option<String>,
-}
-
-fn lookup(word: Word, dict: &[&str]) -> Word {
-    Word {
-        word: dict.get(word.hash % dict.len()).map(|s| s.to_string()),
-        ..word
-    }
-}
-
-impl FromStr for Word {
-    type Err = ParsePhraseError;
-
-    fn from_str(sha: &str) -> ShaResult<Word> {
-        if let Ok(hash) = usize::from_str_radix(&sha, 16) {
-            Ok(Word {
-                sha: sha.to_string(),
-                hash,
-                word: None,
-            })
-        } else {
-            Err(ParsePhraseError::NonHexadecimalCharacters)
-        }
-    }
-}
-
-impl Display for Word {
-    fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
-        if let Some(ref word) = self.word {
-            write!(f, "{}", word)?;
-        }
-        Ok(())
-    }
-}
-
-#[derive(Debug, Eq, PartialEq, Copy, Clone)]
-enum Case {
-    Snake,
-    Kebab,
-    Pascal,
-    Camel,
-    Title,
-    Sentence,
-    Lower,
-    Upper,
-}
-
-#[derive(Debug, Eq, PartialEq)]
-enum ParseCaseError {
-    InvalidFormat,
-}
-
-impl FromStr for Case {
-    type Err = ParseCaseError;
-
-    fn from_str(format: &str) -> Result<Case, ParseCaseError> {
-        let case = match format {
-            "snake" => Case::Snake,
-            "kebab" => Case::Kebab,
-            "pascal" => Case::Pascal,
-            "camel" => Case::Camel,
-            "title" => Case::Title,
-            "sentence" => Case::Sentence,
-            "lower" => Case::Lower,
-            "upper" => Case::Upper,
-            _ => return Err(ParseCaseError::InvalidFormat),
-        };
-
-        Ok(case)
-    }
-}
-
-struct Phrase {
-    adj: Word,
-    adv: Word,
-    noun: Word,
-    format: Case,
-}
-
-impl Phrase {
-    fn with_case(mut self, f: Case) -> Self {
-        self.format = f;
-        self
-    }
-}
-
-impl FromStr for Phrase {
-    type Err = ParsePhraseError;
-
-    fn from_str(sha: &str) -> ShaResult<Phrase> {
-        // Ensure that the sha is at least 8 characters so that
-        // when we extract the first 8 there is something there.
-        let sha = format!("{:0>8}", sha);
-        let adv = lookup(sha[0..3].parse()?, &dictionary::adverbs::WORDS);
-        let adj = lookup(sha[3..5].parse()?, &dictionary::adjectives::WORDS);
-        let noun = lookup(sha[5..8].parse()?, &dictionary::nouns::WORDS);
-
-        Ok(Phrase {
-            adv,
-            adj,
-            noun,
-            format: Case::Lower,
-        })
-    }
-}
-
-impl Display for Phrase {
-    fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
-        use inflector::Inflector;
-
-        let ret = format!("{} {} {}", self.adv, self.adj, self.noun);
-        match self.format {
-            Case::Snake => write!(f, "{}", ret.to_snake_case()),
-            Case::Kebab => write!(f, "{}", ret.to_kebab_case()),
-            Case::Pascal => write!(f, "{}", ret.to_pascal_case()),
-            Case::Camel => write!(f, "{}", ret.to_camel_case()),
-            Case::Title => write!(f, "{}", ret.to_title_case()),
-            Case::Sentence => write!(f, "{}", ret.to_sentence_case()),
-            Case::Lower => write!(f, "{}", ret),
-            Case::Upper => write!(f, "{}", ret.to_uppercase()),
-        }
-    }
-}
+use dictionary::Case;
 
 fn main() {
     let matches = app_matches();
@@ -157,7 +21,7 @@ fn main() {
 
     if let Some(shas) = matches.values_of("SHA") {
         shas.for_each(|sha| {
-            println!("{}", &sha.parse::<Phrase>().unwrap().with_case(format))
+            println!("{}", dictionary::lookup(&sha).unwrap().with_case(format))
         });
     } else if atty::is(Stream::Stdin) {
         from_random_sha(format)
@@ -203,8 +67,7 @@ fn app_matches() -> ArgMatches<'static> {
 fn from_random_sha(format: Case) {
     println!(
         "{}",
-        &format!("{:8x}", rand::random::<usize>())
-            .parse::<Phrase>()
+        dictionary::lookup(&format!("{:8x}", rand::random::<usize>()))
             .unwrap()
             .with_case(format)
     );
@@ -219,7 +82,7 @@ fn from_stdin(format: Case) {
             Ok(size) if size > 0 => {
                 println!(
                     "{}",
-                    &line.trim().parse::<Phrase>().unwrap().with_case(format)
+                    dictionary::lookup(&line.trim()).unwrap().with_case(format)
                 )
             }
             _ => break,
@@ -227,110 +90,3 @@ fn from_stdin(format: Case) {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_can_parse_into_a_word() {
-        let word = Word::from_str("a").unwrap();
-        assert_eq!(word.hash, 10);
-    }
-
-    #[test]
-    fn it_can_detect_non_hex_chars() {
-        let result = Word::from_str("z");
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn it_can_look_up_from_a_dictionary() {
-        let word = lookup(Word::from_str("a").unwrap(), &dictionary::adverbs::WORDS);
-        assert_eq!(word.word, Some("proximally".to_string()));
-    }
-
-    #[test]
-    fn it_will_overflow_the_dictionary_index() {
-        let word = lookup("a".parse().unwrap(), &["hello"]);
-        assert_eq!(word.word, Some("hello".to_string()));
-    }
-
-    #[test]
-    fn it_can_format_the_word() {
-        let word = Word::from_str("a").unwrap();
-        assert_eq!("", format!("{}", word));
-        let word = lookup(word, &dictionary::adverbs::WORDS);
-        assert_eq!("proximally", format!("{}", word));
-    }
-
-    fn make_simple_phrase() -> Phrase {
-        "0a00a00a".parse::<Phrase>().expect("Invalid phrase")
-    }
-
-    #[test]
-    fn a_phrase_can_be_generated_from_a_str() {
-        let phrase = make_simple_phrase();
-        assert_eq!("immeasurably endways borings", format!("{}", phrase));
-    }
-
-    #[test]
-    fn a_phrase_can_be_formatted_as_snake_case() {
-        let phrase = make_simple_phrase().with_case(Case::Snake);
-        assert_eq!("immeasurably_endways_borings", format!("{}", phrase));
-    }
-
-    #[test]
-    fn a_phrase_can_be_formatted_as_kebab_case() {
-        let phrase = make_simple_phrase().with_case(Case::Kebab);
-        assert_eq!("immeasurably-endways-borings", format!("{}", phrase));
-    }
-
-    #[test]
-    fn a_phrase_can_be_formatted_as_camel_case() {
-        let phrase = make_simple_phrase().with_case(Case::Camel);
-        assert_eq!("immeasurablyEndwaysBorings", format!("{}", phrase));
-    }
-
-    #[test]
-    fn a_phrase_can_be_formatted_as_pascal_case() {
-        let phrase = make_simple_phrase().with_case(Case::Pascal);
-        assert_eq!("ImmeasurablyEndwaysBorings", format!("{}", phrase));
-    }
-
-    #[test]
-    fn a_phrase_can_be_formatted_as_title_case() {
-        let phrase = make_simple_phrase().with_case(Case::Title);
-        assert_eq!("Immeasurably Endways Borings", format!("{}", phrase));
-    }
-
-    #[test]
-    fn a_phrase_can_be_formatted_as_capital_case() {
-        let phrase = make_simple_phrase().with_case(Case::Sentence);
-        assert_eq!("Immeasurably endways borings", format!("{}", phrase));
-    }
-
-    #[test]
-    fn a_phrase_can_be_formatted_as_upper_case() {
-        let phrase = make_simple_phrase().with_case(Case::Upper);
-        assert_eq!("IMMEASURABLY ENDWAYS BORINGS", format!("{}", phrase));
-    }
-
-    #[test]
-    fn a_phrase_can_be_formatted_as_lower_case() {
-        let phrase = make_simple_phrase().with_case(Case::Lower);
-        assert_eq!("immeasurably endways borings", format!("{}", phrase));
-    }
-
-    #[test]
-    fn str_can_be_parsed_to_a_format() {
-        assert_eq!(Case::Snake, "snake".parse::<Case>().unwrap());
-        assert_eq!(Case::Kebab, "kebab".parse::<Case>().unwrap());
-        assert_eq!(Case::Camel, "camel".parse::<Case>().unwrap());
-        assert_eq!(Case::Pascal, "pascal".parse::<Case>().unwrap());
-        assert_eq!(Case::Title, "title".parse::<Case>().unwrap());
-        assert_eq!(Case::Sentence, "sentence".parse::<Case>().unwrap());
-        assert_eq!(Case::Lower, "lower".parse::<Case>().unwrap());
-        assert_eq!(Case::Upper, "upper".parse::<Case>().unwrap());
-        assert!("alsdkfj".parse::<Case>().is_err());
-    }
-}


### PR DESCRIPTION
The main file was getting a bit cluttered so I moved the contents into
their own module (`dictionary`). This module contains the structs with
some changes to conform better with the actual use case of the pieces. A
sha is broken into "parts" which then can be looked up for "strings"
instead of words. This seems more semantic and avoids modifying the word
to have a word after passing the sha in.

This is also the first step towards busting it out into a separate
crate.