### PR TITLE
Implement format param for web

### DIFF
--- a/rn-web/src/index.rs
+++ b/rn-web/src/index.rs
@@ -1,0 +1,39 @@
+use actix_web::{Json, Query};
+use std::collections::HashMap;
+use rn_dictionary::{self, Case};
+use param;
+use super::Response;
+
+#[derive(Deserialize)]
+pub struct Params {
+    shas: param::CSV,
+    format: Option<param::Format>,
+}
+
+#[derive(Serialize)]
+pub struct BulkNames {
+    names: HashMap<String, Option<String>>,
+}
+
+impl BulkNames {
+    fn new(names: HashMap<String, Option<String>>) -> Self {
+        Self { names }
+    }
+
+    fn from_list(case: Case, shas: &[String]) -> Self {
+        let mut map = HashMap::new();
+        for sha in shas {
+            let name = rn_dictionary::lookup(&sha)
+                .map(|name| name.with_case(case).to_string())
+                .ok();
+            map.insert(sha.to_string(), name);
+        }
+        Self::new(map)
+    }
+}
+
+pub fn handler(q: Query<Params>) -> Json<Response<BulkNames>> {
+    let format = q.format.unwrap_or(Case::Lower.into());
+
+    Json(Response::new(BulkNames::from_list(*format, &q.shas)))
+}

--- a/rn-web/src/main.rs
+++ b/rn-web/src/main.rs
@@ -3,92 +3,39 @@ extern crate rn_dictionary;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
+extern crate serde_json;
 
-use actix_web::{server, App, HttpResponse, Json, Path, Query, http::{self, StatusCode}};
-use serde::{Deserialize, Deserializer, Serialize};
-use std::collections::HashMap;
-use std::ops::Deref;
+use actix_web::{http, server, App};
+use serde::Serialize;
 
-fn release_name(info: Path<String>) -> HttpResponse {
-    match rn_dictionary::lookup(&info.into_inner()) {
-        Ok(name) => HttpResponse::build(StatusCode::OK).body(name.to_string()),
-        Err(_) => HttpResponse::build(StatusCode::NOT_FOUND).finish(),
-    }
-}
-
-#[derive(Deserialize)]
-struct Params {
-    shas: CSVParam,
-}
-
-struct CSVParam(Vec<String>);
-
-impl Deref for CSVParam {
-    type Target = Vec<String>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl<'de> Deserialize<'de> for CSVParam {
-    fn deserialize<D>(d: D) -> Result<CSVParam, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let s = String::deserialize(d)?;
-        Ok(CSVParam(s.split(',').map(|s| s.to_string()).collect()))
-    }
-}
+mod param;
+mod show;
+mod index;
 
 #[derive(Serialize)]
-struct Response<T>
+pub struct Response<T>
 where
-    T: Serialize
+    T: Serialize,
 {
-    data: T
+    data: T,
 }
 
 impl<T> Response<T>
 where
-    T: Serialize
+    T: Serialize,
 {
-    fn new(data: T) -> Self {
+    pub fn new(data: T) -> Self {
         Self { data }
     }
-}
-
-#[derive(Serialize)]
-struct BulkNames {
-    names: HashMap<String, Option<String>>,
-}
-
-impl BulkNames {
-    fn new(names: HashMap<String, Option<String>>) -> Self {
-        Self { names }
-    }
-
-    fn from_list(shas: &[String]) -> Self {
-        let mut map = HashMap::new();
-        for sha in shas {
-            match rn_dictionary::lookup(&sha) {
-                Ok(name) => map.insert(sha.to_string(), Some(name.to_string())),
-                Err(_) => map.insert(sha.to_string(), None),
-            };
-        }
-        Self::new(map)
-    }
-}
-
-fn release_names(q: Query<Params>) -> Json<Response<BulkNames>> {
-    Json(Response::new(BulkNames::from_list(&q.shas)))
 }
 
 fn main() {
     server::new(|| {
         App::new()
-            .route("/api/release-name", http::Method::GET, release_names)
-            .route("/api/release-name/{sha}", http::Method::GET, release_name)
+            .route("/api/release-name", http::Method::GET, index::handler)
+            .resource("/api/release-name/{sha}", |r| {
+                r.method(http::Method::GET).with2(show::handler)
+            })
     }).bind("0.0.0.0:6767")
         .unwrap()
         .run();

--- a/rn-web/src/param.rs
+++ b/rn-web/src/param.rs
@@ -1,0 +1,78 @@
+use serde::{de, Deserialize, Deserializer};
+use std::ops::Deref;
+use rn_dictionary::Case;
+
+pub struct CSV(Vec<String>);
+
+impl Deref for CSV {
+    type Target = Vec<String>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for CSV {
+    fn deserialize<D>(d: D) -> Result<CSV, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(d)?;
+        Ok(CSV(s.split(',').map(|s| s.to_string()).collect()))
+    }
+}
+
+#[cfg(test)]
+mod csv_test {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn it_can_parse_to_a_vec() {
+        let data = "\"abc,123\"";
+        let csv: CSV = serde_json::from_str(&data).unwrap();
+        assert_eq!(*csv, vec!["abc", "123"]);
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+pub struct Format(Case);
+
+impl Deref for Format {
+    type Target = Case;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for Format {
+    fn deserialize<D>(d: D) -> Result<Format, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(d)?;
+        let case = s.parse::<Case>()
+            .map_err(|_| de::Error::custom("Invalid case format"))?;
+        Ok(Format(case))
+    }
+}
+
+impl From<Case> for Format {
+    fn from(case: Case) -> Format {
+        Format(case)
+    }
+}
+
+#[cfg(test)]
+mod format_test {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn it_can_parse_to_a_vec() {
+        let data = "\"snake\"";
+        let fmt: Format = serde_json::from_str(&data).unwrap();
+        assert_eq!(*fmt, Case::Snake);
+    }
+}

--- a/rn-web/src/show.rs
+++ b/rn-web/src/show.rs
@@ -1,0 +1,16 @@
+use actix_web::{HttpResponse, Path, Query, http::StatusCode};
+use param::Format;
+use rn_dictionary::{self, Case};
+
+#[derive(Deserialize)]
+pub struct Params {
+    format: Option<Format>,
+}
+
+pub fn handler(info: Path<String>, q: Query<Params>) -> HttpResponse {
+    let format = q.format.unwrap_or(Case::Lower.into());
+    match rn_dictionary::lookup(&info.into_inner()) {
+        Ok(name) => HttpResponse::build(StatusCode::OK).body(name.with_case(*format).to_string()),
+        Err(_) => HttpResponse::build(StatusCode::NOT_FOUND).finish(),
+    }
+}


### PR DESCRIPTION
The case of the release names can be specified. As such, this commit
adds the ability to request different formats to the interface.

closes #22 