### PR TITLE
List words via CLI

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -4,7 +4,7 @@ extern crate git_release_name;
 extern crate rand;
 
 use atty::Stream;
-use clap::{App, Arg, ArgMatches};
+use clap::{App, Arg, ArgMatches, SubCommand};
 use std::io::{self, BufRead};
 
 use git_release_name::Case;
@@ -12,27 +12,31 @@ use git_release_name::Case;
 fn main() {
     let matches = app_matches();
 
-    let format = if let Some(fmt) = matches.value_of("format") {
-        fmt.parse().expect("Invalid format specified")
+    if let Some(matches) = matches.subcommand_matches("list") {
+        list::list_dictionary(matches);
     } else {
-        Case::Lower
-    };
+        let format = if let Some(fmt) = matches.value_of("format") {
+            fmt.parse().expect("Invalid format specified")
+        } else {
+            Case::Lower
+        };
 
-    if let Some(shas) = matches.values_of("SHA") {
-        shas.for_each(|sha| {
-            println!(
-                "{}",
-                git_release_name::lookup(&sha)
-                    .expect("Invalid sha")
-                    .with_case(format)
-            )
-        });
-    } else if atty::is(Stream::Stdin) {
-        from_random_sha(format)
-    } else {
-        // no args, check stdin
-        from_stdin(format);
-    };
+        if let Some(shas) = matches.values_of("SHA") {
+            shas.for_each(|sha| {
+                println!(
+                    "{}",
+                    git_release_name::lookup(&sha)
+                        .expect("Invalid sha")
+                        .with_case(format)
+                )
+            });
+        } else if atty::is(Stream::Stdin) {
+            from_random_sha(format)
+        } else {
+            // no args, check stdin
+            from_stdin(format);
+        };
+    }
 }
 
 const FORMAT_OPTIONS: [&'static str; 8] = [
@@ -45,6 +49,27 @@ fn app_matches() -> ArgMatches<'static> {
         .about(
             "Takes a git sha and uses it's relatively unique combination of letters and number \
              to generate a release name",
+        )
+        .subcommand(
+            SubCommand::with_name("list")
+                .about("List out the dictionary words that are in use.")
+                .arg(
+                    Arg::with_name("includes")
+                        .long("include")
+                        .short("i")
+                        .takes_value(true)
+                        .possible_values(&["nouns", "n", "adjectives", "adj", "adverbs", "adv"])
+                        .multiple(true)
+                        .help("Specify which types of words to list."),
+                )
+                .arg(
+                    Arg::with_name("format")
+                        .long("format")
+                        .short("f")
+                        .takes_value(true)
+                        .possible_values(&["csv", "fixed"])
+                        .help("Specify the row format to use"),
+                ),
         )
         .arg(
             Arg::with_name("format")
@@ -60,6 +85,115 @@ fn app_matches() -> ArgMatches<'static> {
             "Each arg should be a sha. If they are less than 8 characters they will be padded",
         ))
         .get_matches()
+}
+
+mod list {
+    use clap::ArgMatches;
+    use git_release_name::{list, Entry, Kind};
+
+    struct List {
+        n: bool,
+        adv: bool,
+        adj: bool,
+    }
+
+    impl List {
+        fn new() -> List {
+            List {
+                n: false,
+                adv: false,
+                adj: false,
+            }
+        }
+
+        fn apply(&mut self, val: &str) {
+            match val {
+                "n" | "nouns" => self.n = true,
+                "adv" | "adverbs" => self.adv = true,
+                "adj" | "adjectives" => self.adj = true,
+                _ => {}
+            }
+        }
+
+        fn entries(self) -> Vec<Entry> {
+            let mut entries = Vec::new();
+            if self.n {
+                entries.append(&mut list(Kind::Noun));
+            }
+            if self.adv {
+                entries.append(&mut list(Kind::Adv));
+            }
+            if self.adj {
+                entries.append(&mut list(Kind::Adj));
+            }
+            if !(self.n || self.adv || self.adj) {
+                entries.append(&mut list(Kind::Noun));
+                entries.append(&mut list(Kind::Adv));
+                entries.append(&mut list(Kind::Adj));
+            }
+            entries
+        }
+    }
+
+    pub fn list_dictionary(matches: &ArgMatches) {
+        let mut list = List::new();
+        if let Some(includes) = matches.values_of("includes") {
+            for val in includes {
+                list.apply(val)
+            }
+        }
+        let entries = list.entries();
+
+        match matches.value_of("format") {
+            Some("csv") => print_csv(&entries),
+            Some("fixed") => print_fixed(&entries),
+            _ => print_fixed(&entries),
+        }
+    }
+
+    fn print_fixed(entries: &[Entry]) {
+        println!(
+            "{kind:>4} {word:<20} {index}",
+            kind = "type",
+            word = "word",
+            index = "index"
+        );
+
+        for entry in entries {
+            println!(
+                "{kind:>4} {word:<20} {index}",
+                kind = match entry.kind {
+                    Kind::Noun => "noun",
+                    Kind::Adj => "adj",
+                    Kind::Adv => "adv",
+                },
+                index = entry.index,
+                word = entry.word
+            )
+        }
+    }
+
+    fn print_csv(entries: &[Entry]) {
+        println!(
+            "{kind},{word},{index}",
+            kind = "type",
+            word = "word",
+            index = "index"
+        );
+
+        for entry in entries {
+            println!(
+                "{kind},{word},{index}",
+                kind = match entry.kind {
+                    Kind::Noun => "noun",
+                    Kind::Adj => "adj",
+                    Kind::Adv => "adv",
+                },
+                index = entry.index,
+                word = entry.word
+            )
+        }
+    }
 }
 
 fn from_random_sha(format: Case) {

--- a/cli/tests/integration.rs
+++ b/cli/tests/integration.rs
@@ -66,4 +66,78 @@ mod integration {
             .contains("issuablyTwinningVerso")
             .unwrap();
     }
+
+    #[test]
+    fn formats_sets_of_words() {
+        Assert::main_binary()
+            .with_args(&["list", "-i", "nouns", "-f", "csv"])
+            .succeeds()
+            .stdout()
+            .contains("noun,aba,3230")
+            .unwrap();
+        Assert::main_binary()
+            .with_args(&["list", "-i", "nouns", "--format", "csv"])
+            .succeeds()
+            .stdout()
+            .contains("noun,aba,3230")
+            .unwrap();
+        Assert::main_binary()
+            .with_args(&["list", "-i", "nouns", "-f", "fixed"])
+            .succeeds()
+            .stdout()
+            .contains("noun aba                  3230")
+            .unwrap();
+        Assert::main_binary()
+            .with_args(&["list", "-i", "nouns", "--format", "fixed"])
+            .succeeds()
+            .stdout()
+            .contains("noun aba                  3230")
+            .unwrap();
+    }
+
+    #[test]
+    fn lists_sets_of_words() {
+        macro_rules! test {
+            (list $($type:expr),*; contains $($word:expr),*) => {
+                Assert::main_binary()
+                    .with_args(&["list" $(, "--include", $type)*])
+                    .succeeds()
+                    $(
+                    .stdout()
+                    .contains($word)
+                    )*
+                    .unwrap();
+                Assert::main_binary()
+                    .with_args(&["list", "-i" $(, $type)*])
+                    .succeeds()
+                    $(
+                    .stdout()
+                    .contains($word)
+                    )*
+                    .unwrap();
+            };
+
+            (list contains $($word:expr),*) => {
+                Assert::main_binary()
+                    .with_args(&["list"])
+                    .succeeds()
+                    $(
+                    .stdout()
+                    .contains($word)
+                    )*
+                    .unwrap();
+            };
+        }
+
+        test!(list contains "verso", "twinning", "issuably");
+        test!(list "nouns"; contains "verso");
+        test!(list "n"; contains "verso");
+        test!(list "adjectives"; contains "twinning");
+        test!(list "adj"; contains "twinning");
+        test!(list "adverbs"; contains "issuably");
+        test!(list "adv"; contains "issuably");
+        test!(list "nouns", "adv"; contains "issuably", "verso");
+        test!(list "nouns", "adj"; contains "twinning", "verso");
+        test!(list "adv", "adj"; contains "twinning", "issuably");
+    }
 }

--- a/dictionary/src/lib.rs
+++ b/dictionary/src/lib.rs
@@ -16,6 +16,40 @@ pub fn lookup(sha: &str) -> Result<Phrase, ParsePhraseError> {
     sha.parse()
 }
 
+/// The kind of word.
+#[derive(Copy, Debug, Clone, PartialEq, Eq)]
+pub enum Kind {
+    /// Noun
+    Noun,
+    /// Adjective
+    Adj,
+    /// Adverb
+    Adv,
+}
+
+/// A word entry in the dictionary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Entry {
+    pub kind: Kind,
+    pub word: String,
+    pub index: usize,
+}
+
+/// Lists out the word for a particular kind of word.
+pub fn list(kind: Kind) -> Vec<Entry> {
+    let list = match kind {
+        Kind::Noun => &nouns::WORDS[..],
+        Kind::Adv => &adverbs::WORDS[..],
+        Kind::Adj => &adjectives::WORDS[..],
+    };
+
+    list.iter()
+        .map(|s| String::from(*s))
+        .enumerate()
+        .map(|(index, word)| Entry { kind, index, word })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -49,5 +83,18 @@ mod tests {
     #[test]
     fn nouns_are_unique() {
         assert!(has_unique_elements(nouns::WORDS.iter()));
+    }
+
+    #[test]
+    fn listing() {
+        assert_eq!(list(Kind::Noun).len(), 4096);
+        assert_eq!(
+            list(Kind::Noun)[0],
+            Entry {
+                word: String::from("kisses"),
+                index: 0,
+                kind: Kind::Noun
+            }
+        )
     }
 }


### PR DESCRIPTION
Opens up the dictionary to expose lists of "entries" comprised of their
index, kind, and the word itself. Then uses this new function to
retrieve and print the words via a command line subcommand. The command
can also be formatted as either csv or fixed width. The word is placed
after the kind so that it can be sorted.

```
$ ./target/debug/git-release-name help list
git-release-name-list
List out the dictionary words that are in use.

USAGE:
    git-release-name list [OPTIONS]

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -f, --format <format>          Specify the row format to use [possible values: csv, fixed]
    -i, --include <includes>...    Specify which types of words to list. [possible values: nouns, n, adjectives, adj,
                                   adverbs, adv]
```